### PR TITLE
fix(core): release native inference resources

### DIFF
--- a/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/engine/PPOcrV6Engine.java
+++ b/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/engine/PPOcrV6Engine.java
@@ -88,20 +88,21 @@ public final class PPOcrV6Engine implements Closeable {
 		log.info("ONNX Runtime provider: {}", String.join(",", providers));
 		this.env = OrtEnvironment.getEnvironment();
 
-		OrtSession.SessionOptions opts = new OrtSession.SessionOptions();
-		try {
-			opts.setIntraOpNumThreads(Math.max(1, config.getIntraOpNumThreads()));
-			opts.setInterOpNumThreads(Math.max(1, config.getInterOpNumThreads()));
-		} catch (OrtException e) {
-			log.warn("设置线程数失败，使用默认值: {}", e.getMessage());
-		}
+		try (OrtSession.SessionOptions opts = new OrtSession.SessionOptions()) {
+			try {
+				opts.setIntraOpNumThreads(Math.max(1, config.getIntraOpNumThreads()));
+				opts.setInterOpNumThreads(Math.max(1, config.getInterOpNumThreads()));
+			} catch (OrtException e) {
+				log.warn("设置线程数失败，使用默认值: {}", e.getMessage());
+			}
 
-		try {
-			this.detSession = env.createSession(config.getDetModelPath(), opts);
-			this.recSession = env.createSession(config.getRecModelPath(), opts);
-		} catch (OrtException e) {
-			close();
-			throw new RuntimeException("创建 ONNX Runtime 会话失败: " + e.getMessage(), e);
+			try {
+				this.detSession = env.createSession(config.getDetModelPath(), opts);
+				this.recSession = env.createSession(config.getRecModelPath(), opts);
+			} catch (OrtException e) {
+				close();
+				throw new RuntimeException("创建 ONNX Runtime 会话失败: " + e.getMessage(), e);
+			}
 		}
 
 		this.detInputName = detSession.getInputNames().iterator().next();
@@ -168,12 +169,17 @@ public final class PPOcrV6Engine implements Closeable {
 		DetectionPreprocessor.Result prep = detPre.call(imgBgr);
 		long[] detShape = toLongArray(prep.shape());
 		FloatBuffer buf = NdArrayUtils.toBuffer(prep.data());
-		Map<String, OnnxTensor> inputs = Collections.singletonMap(detInputName, tensor(buf, detShape));
-		try (OrtSession.Result result = detSession.run(inputs)) {
+		try (OnnxTensor input = tensor(buf, detShape);
+			 OrtSession.Result result = detSession.run(Collections.singletonMap(detInputName, input))) {
 			OnnxTensor outTensor = (OnnxTensor) result.get(0);
 			float[][] prob = readProb2D(outTensor);
-			DbPostProcessor.Result post = detPost.call(probToMat(prob, prep.imgShape()), prep.imgShape());
-			return new DetectResult(post.boxes(), post.scores());
+			Mat probMat = probToMat(prob, prep.imgShape());
+			try {
+				DbPostProcessor.Result post = detPost.call(probMat, prep.imgShape());
+				return new DetectResult(post.boxes(), post.scores());
+			} finally {
+				probMat.release();
+			}
 		} catch (OrtException e) {
 			throw new RuntimeException("det 推理失败: " + e.getMessage(), e);
 		}
@@ -220,8 +226,8 @@ public final class PPOcrV6Engine implements Closeable {
 			RecognitionPreprocessor.Result prep = recPre.call(batch);
 			long[] shape = toLongArray(prep.shape());
 			FloatBuffer buf = NdArrayUtils.toBuffer(prep.data());
-			Map<String, OnnxTensor> inputs = Collections.singletonMap(recInputName, tensor(buf, shape));
-			try (OrtSession.Result result = recSession.run(inputs)) {
+			try (OnnxTensor input = tensor(buf, shape);
+				 OrtSession.Result result = recSession.run(Collections.singletonMap(recInputName, input))) {
 				OnnxTensor outTensor = (OnnxTensor) result.get(0);
 				float[][][] modelOutput = read3D(outTensor);
 				CtcLabelDecoder.Result decoded = recPost.call(modelOutput);
@@ -253,26 +259,33 @@ public final class PPOcrV6Engine implements Closeable {
 		int[][][] sortedBoxes = BoxUtil.sortQuadBoxes(dr.boxes());
 
 		List<Mat> crops = CropUtil.cropByPolys(imgBgr, sortedBoxes);
+		try {
+			List<int[][]> validBoxes = new ArrayList<>();
+			List<Mat> validCrops = new ArrayList<>();
+			for (int i = 0; i < sortedBoxes.length; i++) {
+				if (crops.get(i) != null) {
+					validBoxes.add(sortedBoxes[i]);
+					validCrops.add(crops.get(i));
+				}
+			}
+			if (validCrops.isEmpty()) {
+				return List.of();
+			}
 
-		List<int[][]> validBoxes = new ArrayList<>();
-		List<Mat> validCrops = new ArrayList<>();
-		for (int i = 0; i < sortedBoxes.length; i++) {
-			if (crops.get(i) != null) {
-				validBoxes.add(sortedBoxes[i]);
-				validCrops.add(crops.get(i));
+			RecognizeResult rr = recognize(validCrops);
+
+			List<PPOcrV6Result> results = new ArrayList<>(validBoxes.size());
+			for (int i = 0; i < validBoxes.size(); i++) {
+				results.add(new PPOcrV6Result(rr.texts()[i], rr.scores()[i], validBoxes.get(i)));
+			}
+			return results;
+		} finally {
+			for (Mat crop : crops) {
+				if (crop != null) {
+					crop.release();
+				}
 			}
 		}
-		if (validCrops.isEmpty()) {
-			return List.of();
-		}
-
-		RecognizeResult rr = recognize(validCrops);
-
-		List<PPOcrV6Result> results = new ArrayList<>(validBoxes.size());
-		for (int i = 0; i < validBoxes.size(); i++) {
-			results.add(new PPOcrV6Result(rr.texts()[i], rr.scores()[i], validBoxes.get(i)));
-		}
-		return results;
 	}
 
 	private OnnxTensor tensor(FloatBuffer buf, long[] shape) {
@@ -330,12 +343,17 @@ public final class PPOcrV6Engine implements Closeable {
 		int h = prob.length;
 		int w = prob[0].length;
 		Mat m = new Mat(h, w, org.opencv.core.CvType.CV_32F);
-		float[] flat = new float[h * w];
-		for (int i = 0; i < h; i++) {
-			System.arraycopy(prob[i], 0, flat, i * w, w);
+		try {
+			float[] flat = new float[h * w];
+			for (int i = 0; i < h; i++) {
+				System.arraycopy(prob[i], 0, flat, i * w, w);
+			}
+			m.put(0, 0, flat);
+			return m;
+		} catch (RuntimeException | Error e) {
+			m.release();
+			throw e;
 		}
-		m.put(0, 0, flat);
-		return m;
 	}
 
 	// ==================================================================

--- a/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/postprocessor/DbPostProcessor.java
+++ b/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/postprocessor/DbPostProcessor.java
@@ -59,104 +59,120 @@ public final class DbPostProcessor {
 	public Result call(Mat prob, float[] imgShape) {
 		int srcH = (int) imgShape[0];
 		int srcW = (int) imgShape[1];
+		Mat workingProb = prob;
+		try {
+			if (prob.dims() == 4 && prob.size(0) == 1 && prob.size(1) == 1) {
+				int hNew = prob.size(2);
+				int wNew = prob.size(3);
+				workingProb = prob.reshape(1, hNew);
+				if (workingProb.cols() != wNew) {
+					Mat previous = workingProb;
+					workingProb = previous.reshape(1, wNew);
+					previous.release();
+				}
+			} else if (prob.dims() != 2) {
+				StringBuilder sb = new StringBuilder("DbPostProcessor: 期望 prob 2D (H, W) 或 4D (1, 1, H, W)，实际 (");
+				for (int d = 0; d < prob.dims(); d++) {
+					if (d > 0) sb.append(", ");
+					sb.append(prob.size(d));
+				}
+				sb.append(")");
+				throw new IllegalArgumentException(sb.toString());
+			}
 
-		if (prob.dims() == 4 && prob.size(0) == 1 && prob.size(1) == 1) {
-			int hNew = prob.size(2);
-			int wNew = prob.size(3);
-			prob = prob.reshape(1, hNew);
-			if (prob.cols() != wNew) {
-				prob = prob.reshape(1, wNew);
+			Mat segmentation = new Mat();
+			try {
+				Imgproc.threshold(workingProb, segmentation, thresh, 1.0, Imgproc.THRESH_BINARY);
+				return extractBoxes(workingProb, segmentation, srcW, srcH);
+			} finally {
+				segmentation.release();
 			}
-		} else if (prob.dims() != 2) {
-			StringBuilder sb = new StringBuilder("DbPostProcessor: 期望 prob 2D (H, W) 或 4D (1, 1, H, W)，实际 (");
-			for (int d = 0; d < prob.dims(); d++) {
-				if (d > 0) sb.append(", ");
-				sb.append(prob.size(d));
+		} finally {
+			if (workingProb != prob) {
+				workingProb.release();
 			}
-			sb.append(")");
-			throw new IllegalArgumentException(sb.toString());
 		}
-
-		Mat segmentation = new Mat();
-		Imgproc.threshold(prob, segmentation, thresh, 1.0, Imgproc.THRESH_BINARY);
-		return extractBoxes(prob, segmentation, srcW, srcH);
 	}
 
 	private Result extractBoxes(Mat prob, Mat bitmap, int dstW, int dstH) {
-		Mat u8 = new Mat();
-		Core.multiply(bitmap, new Scalar(255.0), u8);
-		u8.convertTo(u8, CvType.CV_8U);
-
 		List<MatOfPoint> contours = new ArrayList<>();
-		Mat hierarchy = new Mat();
-		Imgproc.findContours(u8, contours, hierarchy, Imgproc.RETR_LIST,
-			Imgproc.CHAIN_APPROX_SIMPLE);
+		Mat u8 = new Mat();
+		Mat hierarchy = null;
+		try {
+			hierarchy = new Mat();
+			Core.multiply(bitmap, new Scalar(255.0), u8);
+			u8.convertTo(u8, CvType.CV_8U);
+			Imgproc.findContours(u8, contours, hierarchy, Imgproc.RETR_LIST,
+				Imgproc.CHAIN_APPROX_SIMPLE);
 
-		int bmH = bitmap.rows();
-		int bmW = bitmap.cols();
-		double ws = (double) dstW / bmW;
-		double hs = (double) dstH / bmH;
+			int bmH = bitmap.rows();
+			int bmW = bitmap.cols();
+			double ws = (double) dstW / bmW;
+			double hs = (double) dstH / bmH;
 
-		List<int[][]> boxList = new ArrayList<>();
-		List<Float> scoreList = new ArrayList<>();
+			List<int[][]> boxList = new ArrayList<>();
+			List<Float> scoreList = new ArrayList<>();
 
-		int n = Math.min(contours.size(), maxCandidates);
-		for (int i = 0; i < n; i++) {
-			MatOfPoint contour = contours.get(i);
-			BoxUtil.MinAreaBox mab;
-			try {
-				mab = BoxUtil.orderMinAreaBoxPoints(contour);
-			} catch (Exception e) {
-				log.debug("minAreaRect 失败, 跳过轮廓 #{}: {}", i, e.getMessage());
-				continue;
+			int n = Math.min(contours.size(), maxCandidates);
+			for (int i = 0; i < n; i++) {
+				MatOfPoint contour = contours.get(i);
+				BoxUtil.MinAreaBox mab;
+				try {
+					mab = BoxUtil.orderMinAreaBoxPoints(contour);
+				} catch (Exception e) {
+					log.debug("minAreaRect 失败, 跳过轮廓 #{}: {}", i, e.getMessage());
+					continue;
+				}
+				if (mab.minSideLen() < minSize) {
+					continue;
+				}
+
+				float[][] pts = mab.asFloatArray();
+				float score = boxScore(prob, pts);
+				if (score < boxThresh) {
+					continue;
+				}
+
+				float[][] expanded = Offset.unclip(pts, Offset.unclipDistance(pts, unclipRatio));
+				if (expanded.length < 3) {
+					continue;
+				}
+
+				BoxUtil.MinAreaBox mab2 = BoxUtil.orderMinAreaBoxPoints(expanded);
+				if (mab2.minSideLen() < minSize + 2) {
+					continue;
+				}
+
+				float[][] boxF = mab2.asFloatArray();
+				int[][] boxI = new int[4][2];
+				for (int k = 0; k < 4; k++) {
+					int x = NdArrayUtils.clamp((int) Math.round(boxF[k][0] * ws), 0, dstW);
+					int y = NdArrayUtils.clamp((int) Math.round(boxF[k][1] * hs), 0, dstH);
+					boxI[k][0] = x;
+					boxI[k][1] = y;
+				}
+				boxList.add(boxI);
+				scoreList.add(score);
 			}
-			if (mab.minSideLen() < minSize) {
-				continue;
-			}
 
-			float[][] pts = mab.asFloatArray();
-			float score = boxScore(prob, pts);
-			if (score < boxThresh) {
-				continue;
+			int[][][] boxes = new int[boxList.size()][4][2];
+			for (int i = 0; i < boxList.size(); i++) {
+				boxes[i] = boxList.get(i);
 			}
-
-			float[][] expanded = Offset.unclip(pts, Offset.unclipDistance(pts, unclipRatio));
-			if (expanded.length < 3) {
-				continue;
+			float[] scores = new float[scoreList.size()];
+			for (int i = 0; i < scoreList.size(); i++) {
+				scores[i] = scoreList.get(i);
 			}
-
-			BoxUtil.MinAreaBox mab2 = BoxUtil.orderMinAreaBoxPoints(expanded);
-			if (mab2.minSideLen() < minSize + 2) {
-				continue;
+			return new Result(boxes, scores);
+		} finally {
+			for (MatOfPoint contour : contours) {
+				contour.release();
 			}
-
-			float[][] boxF = mab2.asFloatArray();
-			int[][] boxI = new int[4][2];
-			for (int k = 0; k < 4; k++) {
-				int x = NdArrayUtils.clamp((int) Math.round(boxF[k][0] * ws), 0, dstW);
-				int y = NdArrayUtils.clamp((int) Math.round(boxF[k][1] * hs), 0, dstH);
-				boxI[k][0] = x;
-				boxI[k][1] = y;
+			if (hierarchy != null) {
+				hierarchy.release();
 			}
-			boxList.add(boxI);
-			scoreList.add(score);
+			u8.release();
 		}
-
-		for (MatOfPoint c : contours) {
-			c.release();
-		}
-		hierarchy.release();
-		u8.release();
-
-		int[][][] boxes = new int[boxList.size()][4][2];
-		for (int i = 0; i < boxList.size(); i++) {
-			boxes[i] = boxList.get(i);
-		}
-		float[] scores = new float[scoreList.size()];
-		for (int i = 0; i < scoreList.size(); i++) {
-			scores[i] = scoreList.get(i);
-		}
-		return new Result(boxes, scores);
 	}
 
 	private float boxScore(Mat bitmap, float[][] polygon) {
@@ -186,22 +202,29 @@ public final class DbPostProcessor {
 		int ww = xMax - xMin + 1;
 		int hh = yMax - yMin + 1;
 		Mat mask = Mat.zeros(hh, ww, CvType.CV_8U);
+		MatOfPoint mop = null;
+		Mat roi = null;
+		try {
+			Point[] shifted = new Point[box.length];
+			for (int i = 0; i < box.length; i++) {
+				shifted[i] = new Point(box[i][0] - xMin, box[i][1] - yMin);
+			}
+			mop = new MatOfPoint(shifted);
+			ArrayList<MatOfPoint> list = new ArrayList<>();
+			list.add(mop);
+			Imgproc.fillPoly(mask, list, new Scalar(1));
 
-		Point[] shifted = new Point[box.length];
-		for (int i = 0; i < box.length; i++) {
-			shifted[i] = new Point(box[i][0] - xMin, box[i][1] - yMin);
+			roi = bitmap.submat(yMin, yMax + 1, xMin, xMax + 1);
+			return (float) Core.mean(roi, mask).val[0];
+		} finally {
+			if (roi != null) {
+				roi.release();
+			}
+			if (mop != null) {
+				mop.release();
+			}
+			mask.release();
 		}
-		MatOfPoint mop = new MatOfPoint(shifted);
-		ArrayList<MatOfPoint> list = new ArrayList<>();
-		list.add(mop);
-		Imgproc.fillPoly(mask, list, new Scalar(1));
-
-		Mat roi = bitmap.submat(yMin, yMax + 1, xMin, xMax + 1);
-
-		Scalar mean = Core.mean(roi, mask);
-		float score = (float) mean.val[0];
-		mask.release();
-		return score;
 	}
 
 	/**

--- a/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/preprocessor/DetectionPreprocessor.java
+++ b/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/preprocessor/DetectionPreprocessor.java
@@ -87,18 +87,28 @@ public final class DetectionPreprocessor {
 		int srcW = imgBgr.cols();
 
 		ResizeOutcome ro = resizeImage(imgBgr, srcH, srcW);
-		Mat norm = normalize(ro.image);
-		int hNew = norm.rows();
-		int wNew = norm.cols();
-		int c = norm.channels();
-		float[] hwcFlat = NdArrayUtils.matToFlatHwc(norm);
-		float[] chw = NdArrayUtils.hwcFlatToNchw(hwcFlat, hNew, wNew, c);
+		Mat norm = null;
+		try {
+			norm = normalize(ro.image);
+			int hNew = norm.rows();
+			int wNew = norm.cols();
+			int c = norm.channels();
+			float[] hwcFlat = NdArrayUtils.matToFlatHwc(norm);
+			float[] chw = NdArrayUtils.hwcFlatToNchw(hwcFlat, hNew, wNew, c);
 
-		float[] shape = new float[]{
-			srcH, srcW,
-			(float) ro.ratioH, (float) ro.ratioW
-		};
-		return new Result(chw, new int[]{1, c, hNew, wNew}, shape);
+			float[] shape = new float[]{
+				srcH, srcW,
+				(float) ro.ratioH, (float) ro.ratioW
+			};
+			return new Result(chw, new int[]{1, c, hNew, wNew}, shape);
+		} finally {
+			if (norm != null) {
+				norm.release();
+			}
+			if (ro.image != imgBgr) {
+				ro.image.release();
+			}
+		}
 	}
 
 	private ResizeOutcome resizeImage(Mat img, int h, int w) {
@@ -126,8 +136,13 @@ public final class DetectionPreprocessor {
 			return new ResizeOutcome(img, 1.0, 1.0);
 		}
 		Mat resized = new Mat();
-		Imgproc.resize(img, resized, new Size(rw, rh), 0, 0, Imgproc.INTER_LINEAR);
-		return new ResizeOutcome(resized, (double) rh / h, (double) rw / w);
+		try {
+			Imgproc.resize(img, resized, new Size(rw, rh), 0, 0, Imgproc.INTER_LINEAR);
+			return new ResizeOutcome(resized, (double) rh / h, (double) rw / w);
+		} catch (RuntimeException | Error e) {
+			resized.release();
+			throw e;
+		}
 	}
 
 	private Mat normalize(Mat img) {
@@ -135,8 +150,12 @@ public final class DetectionPreprocessor {
 		// 处理有 bug（G/R 通道会变成 +Inf），所以这里先转 float32 Mat，
 		// 再用 Java 端循环做归一化 (img * (1/255) - mean) / std。
 		Mat f = NdArrayUtils.toFloat32(img);
-		float[] hwc = NdArrayUtils.matToFlatHwc(f);
-		f.release();
+		float[] hwc;
+		try {
+			hwc = NdArrayUtils.matToFlatHwc(f);
+		} finally {
+			f.release();
+		}
 		int n = hwc.length;
 		int c = 3;
 		int hw = n / c;
@@ -150,8 +169,13 @@ public final class DetectionPreprocessor {
 			hwc[b + 2] = (hwc[b + 2] * scale - meanR) / stdR;
 		}
 		Mat out = new Mat(img.rows(), img.cols(), org.opencv.core.CvType.CV_32FC3);
-		out.put(0, 0, hwc);
-		return out;
+		try {
+			out.put(0, 0, hwc);
+			return out;
+		} catch (RuntimeException | Error e) {
+			out.release();
+			throw e;
+		}
 	}
 
 	/**

--- a/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/preprocessor/RecognitionPreprocessor.java
+++ b/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/preprocessor/RecognitionPreprocessor.java
@@ -98,36 +98,42 @@ public final class RecognitionPreprocessor {
 			int targetW = (int) (h * whRatio);
 
 			int actualW;
-			Mat resized;
-			if (targetW > wMax) {
-				resized = new Mat();
-				Imgproc.resize(img, resized, new Size(wMax, h), 0, 0, Imgproc.INTER_LINEAR);
-				actualW = wMax;
-				targetW = wMax;
-			} else {
-				actualW = Math.min(NdArrayUtils.ceilDiv(h * srcW, srcH), targetW);
-				resized = new Mat();
-				Imgproc.resize(img, resized, new Size(actualW, h), 0, 0, Imgproc.INTER_LINEAR);
-			}
-			widths[i] = targetW;
-			actualWs[i] = actualW;
+			Mat resized = new Mat();
+			try {
+				if (targetW > wMax) {
+					Imgproc.resize(img, resized, new Size(wMax, h), 0, 0, Imgproc.INTER_LINEAR);
+					actualW = wMax;
+					targetW = wMax;
+				} else {
+					actualW = Math.min(NdArrayUtils.ceilDiv(h * srcW, srcH), targetW);
+					Imgproc.resize(img, resized, new Size(actualW, h), 0, 0, Imgproc.INTER_LINEAR);
+				}
+				widths[i] = targetW;
+				actualWs[i] = actualW;
 
-			Mat f = NdArrayUtils.toFloat32(resized);
-			float[] hwcRaw = NdArrayUtils.matToFlatHwc(f);
-			f.release();
-			int nPix = hwcRaw.length;
-			for (int k = 0; k < nPix; k++) {
-				hwcRaw[k] = (hwcRaw[k] / 255.0f - 0.5f) / 0.5f;
+				Mat f = NdArrayUtils.toFloat32(resized);
+				float[] hwcRaw;
+				try {
+					hwcRaw = NdArrayUtils.matToFlatHwc(f);
+				} finally {
+					f.release();
+				}
+				int nPix = hwcRaw.length;
+				for (int k = 0; k < nPix; k++) {
+					hwcRaw[k] = (hwcRaw[k] / 255.0f - 0.5f) / 0.5f;
+				}
+				float[][] chw = new float[CHANNELS][h * actualW];
+				int hw = h * actualW;
+				for (int j = 0; j < hw; j++) {
+					int baseHwc = j * CHANNELS;
+					chw[0][j] = hwcRaw[baseHwc];
+					chw[1][j] = hwcRaw[baseHwc + 1];
+					chw[2][j] = hwcRaw[baseHwc + 2];
+				}
+				perImgChw.add(chw);
+			} finally {
+				resized.release();
 			}
-			float[][] chw = new float[CHANNELS][h * actualW];
-			int hw = h * actualW;
-			for (int j = 0; j < hw; j++) {
-				int baseHwc = j * CHANNELS;
-				chw[0][j] = hwcRaw[baseHwc];
-				chw[1][j] = hwcRaw[baseHwc + 1];
-				chw[2][j] = hwcRaw[baseHwc + 2];
-			}
-			perImgChw.add(chw);
 		}
 
 		int maxW = 0;

--- a/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/utils/BoxUtil.java
+++ b/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/utils/BoxUtil.java
@@ -41,45 +41,53 @@ public class BoxUtil {
 	 */
 	public static MinAreaBox orderMinAreaBoxPoints(MatOfPoint contour) {
 		MatOfPoint2f contour2f = new MatOfPoint2f(contour.toArray());
-		RotatedRect rrect = Imgproc.minAreaRect(contour2f);
-		Mat boxMat = new Mat();
-		Imgproc.boxPoints(rrect, boxMat);
+		Mat boxMat = null;
+		try {
+			boxMat = new Mat();
+			RotatedRect rrect = Imgproc.minAreaRect(contour2f);
+			Imgproc.boxPoints(rrect, boxMat);
 
-		Point[] pts = new Point[4];
-		for (int i = 0; i < 4; i++) {
-			float[] buf = new float[2];
-			boxMat.get(i, 0, buf);
-			pts[i] = new Point(buf[0], buf[1]);
+			Point[] pts = new Point[4];
+			for (int i = 0; i < 4; i++) {
+				float[] buf = new float[2];
+				boxMat.get(i, 0, buf);
+				pts[i] = new Point(buf[0], buf[1]);
+			}
+
+			// 按 x 升序
+			Point[] sorted = pts.clone();
+			Arrays.sort(sorted, Comparator.comparingDouble(p -> p.x));
+
+			// 左侧两个点：y 大者为 TL
+			int tlIdx, blIdx;
+			if (sorted[1].y > sorted[0].y) {
+				tlIdx = 0;
+				blIdx = 1;
+			} else {
+				tlIdx = 1;
+				blIdx = 0;
+			}
+			// 右侧两个点：y 大者为 BR
+			int trIdx, brIdx;
+			if (sorted[3].y > sorted[2].y) {
+				trIdx = 2;
+				brIdx = 3;
+			} else {
+				trIdx = 3;
+				brIdx = 2;
+			}
+
+			Point[] ordered = new Point[]{
+				sorted[tlIdx], sorted[trIdx], sorted[brIdx], sorted[blIdx]
+			};
+			float minSide = (float) Math.min(rrect.size.width, rrect.size.height);
+			return new MinAreaBox(ordered, minSide);
+		} finally {
+			if (boxMat != null) {
+				boxMat.release();
+			}
+			contour2f.release();
 		}
-
-		// 按 x 升序
-		Point[] sorted = pts.clone();
-		Arrays.sort(sorted, Comparator.comparingDouble(p -> p.x));
-
-		// 左侧两个点：y 大者为 TL
-		int tlIdx, blIdx;
-		if (sorted[1].y > sorted[0].y) {
-			tlIdx = 0;
-			blIdx = 1;
-		} else {
-			tlIdx = 1;
-			blIdx = 0;
-		}
-		// 右侧两个点：y 大者为 BR
-		int trIdx, brIdx;
-		if (sorted[3].y > sorted[2].y) {
-			trIdx = 2;
-			brIdx = 3;
-		} else {
-			trIdx = 3;
-			brIdx = 2;
-		}
-
-		Point[] ordered = new Point[]{
-			sorted[tlIdx], sorted[trIdx], sorted[brIdx], sorted[blIdx]
-		};
-		float minSide = (float) Math.min(rrect.size.width, rrect.size.height);
-		return new MinAreaBox(ordered, minSide);
 	}
 
 	/**
@@ -94,8 +102,12 @@ public class BoxUtil {
 			pts[i] = new Point(polygon[i][0], polygon[i][1]);
 		}
 		MatOfPoint mop = new MatOfPoint();
-		mop.fromArray(pts);
-		return orderMinAreaBoxPoints(mop);
+		try {
+			mop.fromArray(pts);
+			return orderMinAreaBoxPoints(mop);
+		} finally {
+			mop.release();
+		}
 	}
 
 	/**

--- a/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/utils/CropUtil.java
+++ b/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/utils/CropUtil.java
@@ -67,40 +67,57 @@ public final class CropUtil {
 		}
 
 		Mat src = new Mat(4, 1, CvType.CV_32FC2);
-		for (int i = 0; i < 4; i++) {
-			src.put(i, 0, pts[i][0], pts[i][1]);
-		}
-		Mat dst = new Mat(4, 1, CvType.CV_32FC2);
-		dst.put(0, 0, 0, 0,
-			cropW, 0,
-			cropW, cropH,
-			0, cropH);
-
-		Mat M;
+		Mat dst = null;
+		Mat transform = null;
 		try {
-			M = Imgproc.getPerspectiveTransform(src, dst);
-		} catch (Exception e) {
-			log.debug("Degenerate quadrilateral in perspective crop, skipping: {}", e.getMessage());
+			for (int i = 0; i < 4; i++) {
+				src.put(i, 0, pts[i][0], pts[i][1]);
+			}
+			dst = new Mat(4, 1, CvType.CV_32FC2);
+			dst.put(0, 0, 0, 0,
+				cropW, 0,
+				cropW, cropH,
+				0, cropH);
+
+			try {
+				transform = Imgproc.getPerspectiveTransform(src, dst);
+			} catch (Exception e) {
+				log.debug("Degenerate quadrilateral in perspective crop, skipping: {}", e.getMessage());
+				return null;
+			}
+
+			Mat cropped = new Mat();
+			try {
+				Imgproc.warpPerspective(img, cropped, transform, new Size(cropW, cropH),
+					Imgproc.INTER_CUBIC, Core.BORDER_REPLICATE, new org.opencv.core.Scalar(0));
+			} catch (RuntimeException | Error e) {
+				cropped.release();
+				throw e;
+			}
+
+			if ((double) cropped.rows() / cropped.cols() >= 1.5) {
+				// np.rot90: 逆时针旋转 90°
+				Mat rotated = new Mat();
+				try {
+					Core.rotate(cropped, rotated, Core.ROTATE_90_COUNTERCLOCKWISE);
+					return rotated;
+				} catch (RuntimeException | Error e) {
+					rotated.release();
+					throw e;
+				} finally {
+					cropped.release();
+				}
+			}
+			return cropped;
+		} finally {
+			if (transform != null) {
+				transform.release();
+			}
 			src.release();
-			dst.release();
-			return null;
+			if (dst != null) {
+				dst.release();
+			}
 		}
-
-		Mat cropped = new Mat();
-		Imgproc.warpPerspective(img, cropped, M, new Size(cropW, cropH),
-			Imgproc.INTER_CUBIC, Core.BORDER_REPLICATE, new org.opencv.core.Scalar(0));
-		M.release();
-		src.release();
-		dst.release();
-
-		if ((double) cropped.rows() / cropped.cols() >= 1.5) {
-			// np.rot90: 逆时针旋转 90°
-			Mat rot = new Mat();
-			Core.rotate(cropped, rot, Core.ROTATE_90_COUNTERCLOCKWISE);
-			cropped.release();
-			return rot;
-		}
-		return cropped;
 	}
 
 	/**
@@ -127,15 +144,27 @@ public final class CropUtil {
 	 */
 	public static List<Mat> cropByPolys(Mat img, int[][][] dtPolys) {
 		List<Mat> results = new ArrayList<>(dtPolys.length);
-		for (int[][] poly : dtPolys) {
-			Mat crop = minAreaRectCrop(img, polyToFloat(poly));
-			if (crop != null && !crop.empty() && crop.rows() > 0 && crop.cols() > 0) {
-				results.add(crop);
-			} else {
-				results.add(null);
+		try {
+			for (int[][] poly : dtPolys) {
+				Mat crop = minAreaRectCrop(img, polyToFloat(poly));
+				if (crop != null && !crop.empty() && crop.rows() > 0 && crop.cols() > 0) {
+					results.add(crop);
+				} else {
+					if (crop != null) {
+						crop.release();
+					}
+					results.add(null);
+				}
 			}
+			return results;
+		} catch (RuntimeException | Error e) {
+			for (Mat crop : results) {
+				if (crop != null) {
+					crop.release();
+				}
+			}
+			throw e;
 		}
-		return results;
 	}
 
 	private static float[][] polyToFloat(int[][] poly) {

--- a/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/utils/NdArrayUtils.java
+++ b/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/utils/NdArrayUtils.java
@@ -65,13 +65,20 @@ public final class NdArrayUtils {
 	 * @return HWC flat float[]
 	 */
 	public static float[] matToFlatHwc(Mat hwc) {
-		Mat m = hwc.isContinuous() ? hwc : hwc.clone();
-		int h = m.rows();
-		int w = m.cols();
-		int c = m.channels();
-		float[] data = new float[h * w * c];
-		m.get(0, 0, data);
-		return data;
+		boolean cloned = !hwc.isContinuous();
+		Mat m = cloned ? hwc.clone() : hwc;
+		try {
+			int h = m.rows();
+			int w = m.cols();
+			int c = m.channels();
+			float[] data = new float[h * w * c];
+			m.get(0, 0, data);
+			return data;
+		} finally {
+			if (cloned) {
+				m.release();
+			}
+		}
 	}
 
 	/**
@@ -272,8 +279,13 @@ public final class NdArrayUtils {
 	 */
 	public static Mat toFloat32(Mat src) {
 		Mat dst = new Mat();
-		src.convertTo(dst, CvType.CV_32F);
-		return dst;
+		try {
+			src.convertTo(dst, CvType.CV_32F);
+			return dst;
+		} catch (RuntimeException | Error e) {
+			dst.release();
+			throw e;
+		}
 	}
 
 	/**

--- a/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/utils/Offset.java
+++ b/mica-ppocr-core/src/main/java/net/dreamlu/mica/ai/ppocr/utils/Offset.java
@@ -150,8 +150,12 @@ public class Offset {
 			pts[i] = new org.opencv.core.Point(polygon[i][0], polygon[i][1]);
 		}
 		org.opencv.core.MatOfPoint2f mop = new org.opencv.core.MatOfPoint2f();
-		mop.fromArray(pts);
-		return org.opencv.imgproc.Imgproc.contourArea(mop);
+		try {
+			mop.fromArray(pts);
+			return org.opencv.imgproc.Imgproc.contourArea(mop);
+		} finally {
+			mop.release();
+		}
 	}
 
 	/**
@@ -169,8 +173,12 @@ public class Offset {
 			pts[i] = new org.opencv.core.Point(polygon[i][0], polygon[i][1]);
 		}
 		org.opencv.core.MatOfPoint2f mop = new org.opencv.core.MatOfPoint2f();
-		mop.fromArray(pts);
-		return org.opencv.imgproc.Imgproc.arcLength(mop, true);
+		try {
+			mop.fromArray(pts);
+			return org.opencv.imgproc.Imgproc.arcLength(mop, true);
+		} finally {
+			mop.release();
+		}
 	}
 
 	/**

--- a/mica-ppocr-core/src/test/java/net/dreamlu/mica/ai/ppocr/engine/PPOcrV6EngineResourceTest.java
+++ b/mica-ppocr-core/src/test/java/net/dreamlu/mica/ai/ppocr/engine/PPOcrV6EngineResourceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019-2026, dreamlu.net All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dreamlu.mica.ai.ppocr.engine;
+
+import net.dreamlu.mica.ai.ppocr.config.PPOcrV6Config;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.Mat;
+import org.opencv.imgcodecs.Imgcodecs;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Verifies that a long-lived engine remains usable after per-run native resources are released.
+ */
+class PPOcrV6EngineResourceTest {
+
+	@BeforeAll
+	static void loadOpenCv() {
+		nu.pattern.OpenCV.loadShared();
+	}
+
+	@Test
+	void repeatedRunProducesStableResults() {
+		Path root = findRepositoryRoot();
+		Path modelDir = root.resolve("models/ppocr-v6/tiny");
+		Mat image = Imgcodecs.imread(root.resolve("test_images/2.png").toString());
+		try {
+			assertFalse(image.empty(), "test image should load");
+
+			PPOcrV6Config config = PPOcrV6Config.builder()
+				.detModelPath(modelDir.resolve("det.onnx").toString())
+				.recModelPath(modelDir.resolve("rec.onnx").toString())
+				.recCharDictPath(modelDir.resolve("dict.txt").toString())
+				.build();
+
+			try (PPOcrV6Engine engine = new PPOcrV6Engine(config)) {
+				List<String> expected = texts(engine.run(image));
+				assertFalse(expected.isEmpty(), "OCR should return at least one result");
+				for (int i = 0; i < 2; i++) {
+					assertEquals(expected, texts(engine.run(image)));
+				}
+			}
+		} finally {
+			image.release();
+		}
+	}
+
+	private static List<String> texts(List<PPOcrV6Result> results) {
+		return results.stream().map(PPOcrV6Result::text).toList();
+	}
+
+	private static Path findRepositoryRoot() {
+		Path current = Path.of("").toAbsolutePath();
+		while (current != null && !Files.isDirectory(current.resolve("models/ppocr-v6/tiny"))) {
+			current = current.getParent();
+		}
+		if (current == null) {
+			throw new IllegalStateException("repository root with test models not found");
+		}
+		return current;
+	}
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix（bug 修复）
- [ ] Feature（新功能）
- [ ] Code style update（代码格式调整）
- [ ] Refactor（重构）
- [ ] Build-related changes（与构建相关的更改）
- [ ] Other, please describe（其他，请说明）

**The description of the PR（PR 描述）:**

Fix native-memory leaks that accumulate when a long-lived PPOcrV6Engine instance handles repeated requests:

- Close detection and recognition input OnnxTensor instances and SessionOptions.
- Release per-run crop and probability Mat instances.
- Add exception-safe cleanup across detection/recognition preprocessing, DB postprocessing, crop/box/offset utilities, and Mat conversion helpers.
- Preserve caller ownership of input images and existing null-skip behavior for invalid crops.
- Add a repeated-run regression test using the real tiny models and sample image.

**Other information（其他信息）:**

Validation:

- mvn package -P '!develop'
- 66 tests, 0 failures, 0 errors, 0 skipped
- Standards review: no blocking violations
- Spec review: no confirmed remaining leak paths or scope expansion

The regression test verifies stable results across repeated calls. It does not directly quantify native-memory usage or inject failures into every exceptional path.